### PR TITLE
Add Notification support with Play/Pause actions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,12 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme.NoActionBar">
+
+        <receiver
+            android:name=".NotificationReceiver"
+            android:enabled="true"
+            android:exported="true" />
+
         <activity
             android:name=".Howtouse" />
         <activity

--- a/app/src/main/java/com/example/she/MyMediaPlayer.java
+++ b/app/src/main/java/com/example/she/MyMediaPlayer.java
@@ -8,16 +8,24 @@ public class MyMediaPlayer {
     static int decidingNumber;
     private static MediaPlayer player = null;
     private static MyMediaPlayer single_inst = null;
+    private static MyMediaPlayerInterface playerInterface = null;
+
+    public interface MyMediaPlayerInterface{
+        public void onPlayClicked();
+        public void onPauseClicked();
+    }
 
     //initialize player
-    private MyMediaPlayer(Context context) {
+    private MyMediaPlayer(Context context,MyMediaPlayerInterface playerInterface) {
         player = MediaPlayer.create(context, R.raw.policesiren);
+        if(playerInterface!=null)
+        this.playerInterface = playerInterface;
     }
 
     //for having only one instance of MyMediaPlayer class
-    public static MyMediaPlayer getInstance(Context context) {
+    public static MyMediaPlayer getInstance(Context context, MyMediaPlayerInterface playerInterface) {
         if (single_inst == null) {
-            single_inst = new MyMediaPlayer(context);
+            single_inst = new MyMediaPlayer(context,playerInterface);
         }
         return single_inst;
     }
@@ -33,6 +41,8 @@ public class MyMediaPlayer {
                 }
             });
             player.start();
+            if(playerInterface != null)
+                playerInterface.onPlayClicked();
         }
         decidingNumber = 1;
     }
@@ -42,6 +52,8 @@ public class MyMediaPlayer {
         if (player != null) {
             player.release();
             player = null;
+            if(playerInterface != null)
+                playerInterface.onPauseClicked();
         }
         single_inst = null;
         decidingNumber = 2;

--- a/app/src/main/java/com/example/she/NotificationReceiver.java
+++ b/app/src/main/java/com/example/she/NotificationReceiver.java
@@ -1,0 +1,29 @@
+package com.example.she;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+import androidx.core.app.NotificationManagerCompat;
+
+public class NotificationReceiver extends BroadcastReceiver{
+
+    final String TAG = "SIREN_NOTIFY";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+
+        if (intent.getAction().equals("pause_clicked")) { //PAUSE clicked
+            MyMediaPlayer.getInstance(context,null).stopPlayer();
+            Log.d(TAG, "ON PAUSE ACTION");
+
+        }else if(intent.getAction().equals("play_clicked")){ //PLAY clicked
+            MyMediaPlayer.getInstance(context,null).play();
+            Log.d(TAG, "ON PLAY ACTION");
+
+        } else {
+            Log.d(TAG, "Something went wrong");
+        }
+    }
+}

--- a/app/src/main/java/com/example/she/siren.java
+++ b/app/src/main/java/com/example/she/siren.java
@@ -1,26 +1,48 @@
 package com.example.she;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
 
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.media.MediaPlayer;
+import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.google.gson.Gson;
 
-public class siren extends AppCompatActivity {
+public class siren extends AppCompatActivity implements MyMediaPlayer.MyMediaPlayerInterface {
 
     Button stop, play;
     TextView stopText, playText;
+
+    public static final String CHANNEL_ID = "siren_channel";
+    public static final String CHANNEL_NAME = "siren";
+    public static final String CHANNEL_DESC= "play_pause_siren";
+    NotificationManagerCompat notificationManagerCompat;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_siren);
+
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O){
+            NotificationChannel channel = new NotificationChannel(CHANNEL_ID,
+                    CHANNEL_NAME, NotificationManager.IMPORTANCE_LOW);
+            channel.setDescription(CHANNEL_DESC);
+            NotificationManager manager = getSystemService(NotificationManager.class);
+            manager.createNotificationChannel(channel);
+        }
 
         playText = findViewById(R.id.txt_view3);
         stopText = findViewById(R.id.txt_view4);
@@ -28,6 +50,49 @@ public class siren extends AppCompatActivity {
         stop = findViewById(R.id.b6);
 
         decide(MyMediaPlayer.decidingNumber);
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        decide(MyMediaPlayer.decidingNumber);
+        MyMediaPlayer.getInstance(this,this);
+    }
+
+    private void displaySirenNotification(){
+        Intent intent = new Intent(this, siren.class);
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+        PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+
+        Intent playIntent = new Intent(this, NotificationReceiver.class);
+        playIntent.setAction("play_clicked");
+        PendingIntent playPendingIntent =
+                PendingIntent.getBroadcast(getApplicationContext(),
+                        2,
+                        playIntent,
+                        PendingIntent.FLAG_UPDATE_CURRENT);
+
+        Intent pauseIntent = new Intent(this, NotificationReceiver.class);
+        pauseIntent.setAction("pause_clicked");
+        PendingIntent pausePendingIntent =
+                PendingIntent.getBroadcast(getApplicationContext(),
+                        2,
+                        pauseIntent,
+                        PendingIntent.FLAG_UPDATE_CURRENT);
+
+        NotificationCompat.Builder mBuilder = new NotificationCompat
+                .Builder(this,CHANNEL_ID)
+                .setSmallIcon(R.drawable.logo1)
+                .setContentTitle("Fake Siren")
+                .setContentText("Play or Pause siren")
+                .setPriority(Notification.PRIORITY_LOW)
+                .setAutoCancel(false)
+                .setContentIntent(pendingIntent)
+                .addAction(R.mipmap.stop,"PLAY",playPendingIntent)
+                .addAction(R.mipmap.stop,"PAUSE",pausePendingIntent);
+
+        notificationManagerCompat = NotificationManagerCompat.from(this);
+        notificationManagerCompat.notify(1,mBuilder.build());
     }
 
     public void decide(int number) {
@@ -48,14 +113,27 @@ public class siren extends AppCompatActivity {
     }
 
     public void play(View view) {
-        MyMediaPlayer.getInstance(this).play();
+        MyMediaPlayer.getInstance(this,this).play();
         MyMediaPlayer.decidingNumber = 1;
         decide(MyMediaPlayer.decidingNumber);
+
+        displaySirenNotification();
     }
 
     public void stop(View v) {
-        MyMediaPlayer.getInstance(this).stopPlayer();
+        MyMediaPlayer.getInstance(this,this).stopPlayer();
         MyMediaPlayer.decidingNumber = 0;
         decide(MyMediaPlayer.decidingNumber);
+    }
+
+    @Override
+    public void onPlayClicked() {
+        decide(1);
+    }
+
+    @Override
+    public void onPauseClicked() {
+        Toast.makeText(this,"Siren Paused",Toast.LENGTH_SHORT).show();
+        decide(2);
     }
 }


### PR DESCRIPTION
Solves: Issue #36 
* Now when user play fake siren a notification is displayed in Notification Drawer
* It has two actions - Play and Pause
* On clicking any action, respective action will be performed.
* This helps user not to return back to the same activity to play or pause siren.
* Also, On clicking notification, user will be redirected to the siren activity page.

Screenshot:
![screenshort_notification](https://user-images.githubusercontent.com/59572531/107943507-d26aab80-6fb2-11eb-9dd6-98298555ec77.jpg)
