### PR TITLE
Bug Fix - App crashed on opening AddRelative page

### DIFF
--- a/app/src/main/res/layout/activity_addrelative.xml
+++ b/app/src/main/res/layout/activity_addrelative.xml
@@ -11,7 +11,7 @@
     <ImageView
         android:layout_width="100dp"
         android:layout_height="100dp"
-        android:src="@drawable/logo"
+        android:src="@drawable/logo1"
         android:layout_marginTop="20dp"/>
 
     <com.google.android.material.textfield.TextInputLayout


### PR DESCRIPTION
Solves Bug #48 
 
**Bug resolved**
* Change the logo image from logo to logo1
* Previous image was too large for few device to load